### PR TITLE
Instruct people to install Python 3, not Python 2

### DIFF
--- a/index.html
+++ b/index.html
@@ -424,7 +424,7 @@ p
       </p>
     </div>
   </div>
-<div> <!-- End of 'shell' section. -->
+</div> <!-- End of 'shell' section. -->
 
 <div id='git'> <!-- Start of 'Git' section. GitHub browser compatability
            is given at https://help.github.com/articles/supported-browsers/-->
@@ -490,9 +490,9 @@ p
 
     <p>
       Regardless of how you choose to install it,
-      <strong>please make sure you install Python version 2.x and not version 3.x</strong>
-      (e.g., 2.7 is fine but not 3.4).
-      Python 3 introduced changes that will break some of the code we teach during the workshop.
+      <strong>please make sure you install Python version 3.x and not version 2.x</strong>
+      (e.g., 3.4 is fine but not 2.7).
+      We will teach this workshop using Python 3.
     </p>
 
     <p>
@@ -500,7 +500,7 @@ p
       that runs in a web browser. For this to work you will need a reasonably
       up-to-date browser. The current versions of the Chrome, Safari and
       Firefox browsers are all <a 
-      href='http://ipython.org/ipython-doc/2/install/install.html#browser-compatibility'>supported</a> 
+      href='http://ipython.org/ipython-doc/3/install/install.html#browser-compatibility'>supported</a> 
       (some older browsers, including Internet Explorer version 9 
       and below, are not).
     </p>
@@ -511,10 +511,10 @@ p
       <ul>
 	<li>
           Download and
-          install <a href="https://store.continuum.io/cshop/anaconda/">Anaconda</a>.
+          install <a href="http://continuum.io/downloads#py34">Anaconda</a>.
 	</li>
 	<li>
-          Download the default Python 2 installer (do not follow the link to version 3).
+          Download the Python 3 installer from that link (do not switch to version 2).
 	  Use all of the defaults for installation
           <em>except</em> make sure to check
 	  <strong>Make Anaconda the default Python</strong>.
@@ -526,10 +526,10 @@ p
       <ul>
 	<li>
           Download and
-          install <a href="https://store.continuum.io/cshop/anaconda/">Anaconda</a>.
+          install <a href="http://continuum.io/downloads#py34">Anaconda</a>.
 	</li>
 	<li>
-          Download the default Python 2 installer (do not follow the link to version 3).
+          Download the Python 3 installer from that link (do not switch to version 2).
 	  Use all of the defaults for installation.
 	</li>
       </ul>
@@ -538,7 +538,7 @@ p
       <h4 id="python-linux">Linux</h4>
       <p>
 	We recommend the all-in-one scientific Python installer
-	<a href="http://continuum.io/downloads.html">Anaconda</a>.
+	<a href="http://continuum.io/downloads#py34">Anaconda</a>.
 	(Installation requires using the shell and if you aren't
 	comfortable doing the installation yourself just
 	download the installer and we'll help you at the boot
@@ -548,7 +548,7 @@ p
 	<li>
           Download the installer that matches your operating
           system and save it in your home folder.
-	  Download the default Python 2 installer (do not follow the link to version 3). 
+	  Download the Python 3 installer (do not switch to version 2).
 	</li>
 	<li>
           Open a terminal window.


### PR DESCRIPTION
I wanted to get this changed first, to catch people who might be getting set up in advance.
