### PR TITLE
Remove Lesson Expansion link from the web-page

### DIFF
--- a/shell/index.md
+++ b/shell/index.md
@@ -50,7 +50,6 @@ These lessons will start you on a path towards using these resources effectively
 9.  [Working Remotely](08-ssh.html)
 10. [Variables](09-var.html)
 11. [Job Control](10-job.html)
-12. [Expansion](11-expansion.html)
 
 ## Other Resources
 


### PR DESCRIPTION
@katyhuff can you please build the side again? I made took the Expansions lessons from index.md.
